### PR TITLE
Change "Anaconda CE" to "Anaconda" and point directly to download site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or 2.7 for this tutorial.
 
 For users who do not yet have these  packages installed, a relatively
 painless way to install all the requirements is to use a package such as
-[Anaconda CE](http://store.continuum.io/ "Anaconda CE"), which can be
+[Anaconda](http://www.continuum.io/downloads "Anaconda"), which can be
 downloaded and installed for free.
 
 ## Downloading the Tutorial Materials

--- a/notebooks/00_Preliminaries.ipynb
+++ b/notebooks/00_Preliminaries.ipynb
@@ -118,7 +118,7 @@
       "- `scikit-learn` version 0.12 or later: http://scikit-learn.org\n",
       "- `ipython` version 1.0 or later, with notebook support: http://ipython.org\n",
       "\n",
-      "The easiest way to get these is to use an all-in-one installer such as [Anaconda CE](https://store.continuum.io/) from Continuum. These are available for multiple architectures."
+      "The easiest way to get these is to use an all-in-one installer such as [Anaconda](http://www.continuum.io/downloads) from Continuum. These are available for multiple architectures."
      ]
     },
     {


### PR DESCRIPTION
Remove references to Anaconda CE --- there is no Anaconda CE anymore.  Anaconda is the free distribution
