### PR TITLE
Denote length of label vector differently

### DIFF
--- a/notebooks/02_data_representation.ipynb
+++ b/notebooks/02_data_representation.ipynb
@@ -83,7 +83,7 @@
       "$$\n",
       "\n",
       "$$\n",
-      "{\\rm label~vector:~~~} {\\bf y}~=~ [y_1, y_2, y_3, \\cdots y_N]\n",
+      "{\\rm label~vector:~~~} {\\bf y}~=~ [y_1, y_2, y_3, \\cdots y_M]\n",
       "$$\n",
       "\n",
       "Here there are $N$ samples and $D$ features."


### PR DESCRIPTION
There is no reason for the number of labels to be the same as the number of samples (here denoted by N).  That's why I'm suggesting M... (could be L, like 'labels', but number of features is denoted by D, not F, so why not M :))
